### PR TITLE
Fixed "Name" field not showing in MongoDB

### DIFF
--- a/Eshop.Domain/Customers/Customer.cs
+++ b/Eshop.Domain/Customers/Customer.cs
@@ -1,17 +1,20 @@
 ﻿using Eshop.Domain.SeedWork;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace Eshop.Domain.Customers;
 
 public class Customer : Entity, IAggregateRoot
 {
-    public string Name { get; }    
+    [BsonRepresentation(BsonType.String)]
+    public string Name { get; private set; }    
         
-    public static Customer Create(Guid id, string name)
+    public static Customer Create(string name)
     {
-        return new(id, name);
+        return new(name);
     }
 
-    private Customer(Guid id, string name) : base(Guid.NewGuid())
+    private Customer(string name) : base(Guid.NewGuid())
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
     }


### PR DESCRIPTION

Before (no **Name** field):
![Image](https://github.com/user-attachments/assets/bb9ae653-f274-4b6c-a841-140533bd96b8)
After:
![Image](https://github.com/user-attachments/assets/5790bbf6-0884-4c6e-bf9a-ca4d09db33c7)

Adding `private set;` to Name property fixed the problem.
![Image](https://github.com/user-attachments/assets/03245a7e-5cd4-40d4-8a47-7c53910a6055)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the customer creation process by simplifying the `Create` method and constructor to only require a name.
	- Enhanced encapsulation of the `Name` property by changing its setter to private.
- **Bug Fixes**
	- Improved error handling by ensuring a null check for the `name` parameter during customer instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->